### PR TITLE
Add Attribute annotation to angular2.d.ts

### DIFF
--- a/typings/angular2/angular2.d.ts
+++ b/typings/angular2/angular2.d.ts
@@ -39,4 +39,5 @@ declare module "angular2/angular2" {
     });
   function For();
   function If();
+  function Attribute(attributeName: string);
 }


### PR DESCRIPTION
Without this addition the TS compiler issues this error:

```
error TS2305: Module '"angular2/angular2"' has no exported member 'Attribute'.
```

when you attempt to `import {Attribute} from 'angular2/angular2';`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/ts-quickstart/5)

<!-- Reviewable:end -->
